### PR TITLE
chore: Update badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wait-for
 
-[![CI](https://github.com/poi2/wait-for-rs/workflows/CI/badge.svg)](https://github.com/poi2/wait-for-rs/actions)
+[![Build Status](https://github.com/poi2/wait-for-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/poi2/wait-for-rs/actions)
 [![Crates.io](https://img.shields.io/crates/v/wait-for-rs.svg)](https://crates.io/crates/wait-for-rs)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](https://github.com/poi2/wait-for-rs)
 


### PR DESCRIPTION
## Description

Update badge on README.
I missed updating the badge after renaming the CI workflow.

## Changes

- Update CI badge URL in `README.md` to use file-based format

## Test

- [x] Local testing completed
- [x] CI passes
